### PR TITLE
fix: change package name and remove unnecessary statements in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@
            skills = ['gym_sql_skill'];
        ```
        Here `gms_ai_agent` is the name of the AGENT which is using `gym_nlq_model` as the MODEL and `gym_sql_skill` as the SKILL, which will be used by the AGENT to execute queries and provide responses based on the data it has access to.<br><br>
-  7. **Ask a Question to the AGENT** - After creating the AGENT, you can ask questions to the AGENT and it will respond with the generated SQL query or the result of the query.
+  7. **Ask a Question to the AGENT** - After creating the AGENT, you can ask questions to the AGENT and it will respond with the generated SQL query.
      * **Command to Ask a Question to the AGENT**<br><br>
        ```sql
        SELECT answer
@@ -203,13 +203,13 @@
      ```
      This file will be used to store the connection details for MindsDB and your local MySQL database. Make sure to replace the placeholders with your actual connection details and `.gitignore` this file to avoid committing sensitive information to your version control system.<br><br>
 4. **Create `MindsDBAgentService.java` class**
-   * Create a `MindsDBAgentService.java` class under `org.example.gmsnql` package and this file is used handle all MindsDB operations.
+   * Create a `MindsDBAgentService.java` class under `org.example.gmsnlq` package and this file is used to handle all MindsDB operations.
    * Through this class, you can connect to MindsDB, execute queries, and get the results from the AGENT.<br><br>
 5. **Create `RealDatabaseService.java` class**
-   * Create a `RealDatabaseService.java` class under `org.example.gmsnql` package and this file is used to connect to your local MySQL database.
+   * Create a `RealDatabaseService.java` class under `org.example.gmsnlq` package and this file is used to connect to your local MySQL database.
    * This class will be used to execute the SQL query which is returned by the AGENT and get the results from the local MySQL database.<br><br>
 6. **Create `TablePrinter.java` class**
-   * Create a `TablePrinter.java` class under `org.example.gmsnql` package and this file is used to print the query results in a tabular format.<br><br>
+   * Create a `TablePrinter.java` class under `org.example.gmsnlq` package and this file is used to print the query results in a tabular format.<br><br>
 7. **Update `Main.java` class**
-   * Update the `Main.java` class contents under `org.example.gmsnql` package to use the `MindsDBAgentService`, `RealDatabaseService` and `TablePrinter` classes to connect to MindsDB, get the results from the AGENT based on the question asked that is the correct SQL query and execute it on the local MySQL database to get the results and print them in a tabular format.
+   * Update the `Main.java` class contents under `org.example.gmsnlq` package to use the `MindsDBAgentService`, `RealDatabaseService` and `TablePrinter` classes to connect to MindsDB, get the results from the AGENT based on the question asked that is the correct SQL query and execute it on the local MySQL database to get the results and print them in a tabular format.
    * The `Main.java` class will be the entry point of your application.

--- a/src/main/java/org/example/gmsnlq/Main.java
+++ b/src/main/java/org/example/gmsnlq/Main.java
@@ -1,4 +1,4 @@
-package org.example.gmsnql;
+package org.example.gmsnlq;
 
 import java.io.FileInputStream;
 import java.sql.ResultSet;

--- a/src/main/java/org/example/gmsnlq/MindsDBAgentService.java
+++ b/src/main/java/org/example/gmsnlq/MindsDBAgentService.java
@@ -1,4 +1,4 @@
-package org.example.gmsnql;
+package org.example.gmsnlq;
 
 import java.sql.*;
 

--- a/src/main/java/org/example/gmsnlq/RealDatabaseService.java
+++ b/src/main/java/org/example/gmsnlq/RealDatabaseService.java
@@ -1,4 +1,4 @@
-package org.example.gmsnql;
+package org.example.gmsnlq;
 
 import java.sql.*;
 

--- a/src/main/java/org/example/gmsnlq/TablePrinter.java
+++ b/src/main/java/org/example/gmsnlq/TablePrinter.java
@@ -1,4 +1,4 @@
-package org.example.gmsnql;
+package org.example.gmsnlq;
 
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;


### PR DESCRIPTION
i have renamed the package name from org.example.gmsnql to org.example.gmsnlq and the changes are refactored in all 4 java classes and also in README file.